### PR TITLE
Add --fill option for black/white ROI crop padding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+## Project overview
+
+**mbari-aidata** — CLI for ETL and dataset download on MBARI AI workflows (Tator, Redis, COCO/VOC/CIFAR export, localization crops, etc.). Python 3.10+, Poetry, semantic-release on `main`.
+
+**Architecture map:** `graphify-out/GRAPH_REPORT.md`; refresh with `graphify update .` after code changes.
+
+---
+
+## File headers (required)
+
+Add this 3-line header to **every new or substantially edited** Python module under `mbari_aidata/` and `tests/`:
+
+```python
+# mbari_aidata, Apache-2.0 license
+# Filename: <path relative to mbari_aidata/ or tests/>
+# Description: <one-line summary of the module>
+```
+
+Example (`generators/utils.py`):
+
+```python
+# mbari_aidata, Apache-2.0 license
+# Filename: generators/utils.py
+# Description: Algorithms to run on lists of localizations to combine them and crop frames
+```
+
+---
+
+## Commits (semantic-release)
+
+Use **Angular-style** commit messages so `python-semantic-release` can version correctly (`pyproject.toml`).
+
+**Format:** `<type>[optional scope]: <description>`
+
+**Allowed types:** `feat`, `fix`, `perf`, `docs`, `build`, `ci`, `chore`, `style`, `refactor`, `test`
+
+| Type | Release impact |
+|------|----------------|
+| `feat` | Minor bump |
+| `fix`, `perf` | Patch bump |
+| Others | Typically no version bump (see changelog exclude patterns) |
+
+**Examples:**
+
+- `feat: add ROI crop padding option for VOC export`
+- `fix(generators): clip bbox to frame bounds in build_roi_crop_filter`
+- `test: cover white-fill padding in roi crop filter`
+
+Do **not** use ad-hoc prefixes (`Update`, `WIP`, version-only messages) for changes that should ship.
+
+---
+
+## Pull requests
+
+- **Max size:** 400 lines changed (additions + deletions) per PR. Split larger work into stacked or sequential PRs.
+- **Labels (required):** Apply GitHub labels in this form before requesting review:
+
+| Label | Meaning (pick one per dimension) |
+|-------|----------------------------------|
+| `type/feature` | New capability |
+| `type/fix` | Bug fix |
+| `type/docs` | Documentation only |
+| `type/refactor` | Behavior-preserving restructure |
+| `type/test` | Tests only |
+| `type/chore` | Tooling, deps, CI |
+| `scope/commands` | `mbari_aidata/commands/` |
+| `scope/generators` | `mbari_aidata/generators/` |
+| `scope/plugins` | `mbari_aidata/plugins/` |
+| `scope/predictors` | `mbari_aidata/predictors/` |
+| `scope/tests` | `tests/` |
+| `scope/infra` | CI, Docker, packaging |
+| `impact/low` | Small, localized risk |
+| `impact/medium` | Moderate behavior or API surface |
+| `impact/high` | Breaking or wide blast radius |
+| `status/needs-review` | Ready for human review |
+
+Example set: `type/feature`, `scope/generators`, `impact/medium`, `status/needs-review`
+
+---
+
+## Testing
+
+Run tests from the repo root after substantive changes (see `README.md` / project docs for full setup).
+
+---
+
+## Graphify
+
+Before answering architecture or “how does X connect to Y?” questions, read `graphify-out/GRAPH_REPORT.md`. After editing code in a session, run `graphify update .` (AST-only, no API cost).

--- a/mbari_aidata/commands/download.py
+++ b/mbari_aidata/commands/download.py
@@ -50,6 +50,12 @@ DEFAULT_BASE_DIR = Path.home() / "mbari_aidata" / "datasets"
     ),
 )
 @click.option("--resize", type=int, help="Resize images to this size after cropping them.")
+@click.option(
+    "--fill",
+    type=click.Choice(["black", "white"], case_sensitive=False),
+    default=None,
+    help="Fill color for padding when squaring ROI crops near image edges (requires --crop-roi).",
+)
 @click.option("--voc", is_flag=True, help="True if export as VOC dataset, False if not.")
 @click.option("--coco", is_flag=True, help="True if export as COCO dataset, False if not.")
 @click.option("--cifar", is_flag=True, help="True if export as CIFAR dataset, False if not.")
@@ -79,6 +85,7 @@ def download(
     crop_roi: bool,
     external_video_root: Optional[Path],
     resize: int,
+    fill: Optional[str],
     voc: bool,
     cifar: bool,
     coco: bool,
@@ -103,6 +110,8 @@ def download(
                     f"Not a directory: {external_video_root}",
                     param_hint="--external-video-root",
                 )
+        if fill is not None and not crop_roi:
+            raise click.UsageError("--fill requires --crop-roi")
         base_path.mkdir(exist_ok=True, parents=True)
         # Load the configuration file
         config_dict = init_yaml_config(config)
@@ -182,7 +191,8 @@ def download(
             cifar=cifar,
             crop_roi=crop_roi,
             external_video_root=external_video_root,
-            resize=resize
+            resize=resize,
+            fill=fill,
         )
         return success
     except Exception as e:

--- a/mbari_aidata/generators/coco_voc.py
+++ b/mbari_aidata/generators/coco_voc.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 from pascal_voc_writer import Writer  # type: ignore
 from mbari_aidata.logger import debug, info, err, exception
 from mbari_aidata.generators.cifar import create_cifar_dataset
-from mbari_aidata.generators.utils import combine_localizations, crop_frame
+from mbari_aidata.generators.utils import build_roi_crop_filter, combine_localizations, crop_frame
 from tator.openapi.tator_openapi import Localization  
 
 def resolve_external_video_file(root: Path, media_name: str) -> Optional[Path]:
@@ -62,7 +62,8 @@ def download(
     cifar: bool = False,
     crop_roi: bool = False,
     external_video_root: Optional[Path] = None,
-    resize: int = 0
+    resize: int = 0,
+    fill: Optional[str] = None,
 ) -> bool:
     """
     Download a dataset based on a version tag for training
@@ -93,6 +94,7 @@ def download(
     :param external_video_root: (optional) Directory containing source videos for ROI cropping. For a given
         Tator media item, the stem is matched and <stem>.mov is preferred, else <stem>.mp4.
     :param resize: (optional) Resize images to this size after cropping thems
+    :param fill: (optional) Fill color (``black`` or ``white``) for squaring ROI crops near image edges
     :return: True if the dataset was created successfully, False otherwise
     """
     try:
@@ -412,11 +414,8 @@ def download(
 
             # Crop the ROI from the original images/video in batches of 500
             batch_size = 500
-            scale_filter = ""
             # Prepare for parallel processing  - use all available CPUs
             max_workers = os.cpu_count()
-            if resize:
-                scale_filter = f"scale={resize}:{resize}"
             for i in range(0, len(all_media), batch_size):
                 batch = all_media[i:i + batch_size]
                 with concurrent.futures.ThreadPoolExecutor(max_workers) as executor:
@@ -463,27 +462,19 @@ def download(
                                 y1 = int(media.height * c.y)
                                 x2 = int(media.width * (c.x + c.width))
                                 y2 = int(media.height * (c.y + c.height))
-                                width = x2 - x1
-                                height = y2 - y1
-                                shorter_side = min(height, width)
-                                longer_side = max(height, width)
-                                delta = abs(longer_side - shorter_side)
-
-                                padding = delta // 2
-                                if width == shorter_side:
-                                    x1 -= padding
-                                    x2 += padding
-                                else:
-                                    y1 -= padding
-                                    y2 += padding
-
-                                # Ensure coordinates don't go out of bounds
-                                x1, x2, y1, y2 = max(0, x1), min(media.width, x2), max(0, y1), min(media.height, y2)
-
-                                if resize:
-                                    crop_filter[frame].append(f"crop={x2 - x1}:{y2 - y1}:{x1}:{y1},{scale_filter}")
-                                else:
-                                    crop_filter[frame].append(f"crop={x2 - x1}:{y2 - y1}:{x1}:{y1}")
+                                filter_str = build_roi_crop_filter(
+                                    x1,
+                                    y1,
+                                    x2,
+                                    y2,
+                                    media.width,
+                                    media.height,
+                                    resize=resize or 0,
+                                    fill=fill,
+                                )
+                                if not filter_str:
+                                    continue
+                                crop_filter[frame].append(filter_str)
 
                                 output_maps[frame].append(f'"{output_file}"')
 

--- a/mbari_aidata/generators/utils.py
+++ b/mbari_aidata/generators/utils.py
@@ -1,7 +1,7 @@
 # mbari_aidata, Apache-2.0 license
 # Filename: generators/utils.py
 # Description: Algorithms to run on lists of localizations to combine them and crop frames
-from typing import List
+from typing import List, Optional
 from tator.openapi.tator_openapi import Localization  # type: ignore
 import torch
 from torchvision.ops import nms
@@ -10,6 +10,68 @@ import subprocess
 import os
 
 from mbari_aidata.logger import err, debug
+
+
+def build_roi_crop_filter(
+    x1: int,
+    y1: int,
+    x2: int,
+    y2: int,
+    media_width: int,
+    media_height: int,
+    resize: int = 0,
+    fill: Optional[str] = None,
+) -> str:
+    """
+    Build an ffmpeg video filter to crop a localization ROI to a square.
+
+    When ``fill`` is ``black`` or ``white``, out-of-bounds padding needed to
+    square the crop is filled with that color instead of clipping the ROI.
+    """
+    width = x2 - x1
+    height = y2 - y1
+    shorter_side = min(height, width)
+    longer_side = max(height, width)
+    padding = abs(longer_side - shorter_side) // 2
+
+    sq_x1, sq_y1, sq_x2, sq_y2 = x1, y1, x2, y2
+    if width == shorter_side:
+        sq_x1 -= padding
+        sq_x2 += padding
+    else:
+        sq_y1 -= padding
+        sq_y2 += padding
+
+    if fill:
+        ideal_size = sq_x2 - sq_x1
+        crop_x1 = max(0, sq_x1)
+        crop_y1 = max(0, sq_y1)
+        crop_x2 = min(media_width, sq_x2)
+        crop_y2 = min(media_height, sq_y2)
+        crop_w = crop_x2 - crop_x1
+        crop_h = crop_y2 - crop_y1
+        if crop_w <= 0 or crop_h <= 0:
+            return ""
+        pad_x = crop_x1 - sq_x1
+        pad_y = crop_y1 - sq_y1
+        crop_filter = (
+            f"crop={crop_w}:{crop_h}:{crop_x1}:{crop_y1},"
+            f"pad={ideal_size}:{ideal_size}:{pad_x}:{pad_y}:{fill}"
+        )
+    else:
+        crop_x1 = max(0, sq_x1)
+        crop_y1 = max(0, sq_y1)
+        crop_x2 = min(media_width, sq_x2)
+        crop_y2 = min(media_height, sq_y2)
+        crop_w = crop_x2 - crop_x1
+        crop_h = crop_y2 - crop_y1
+        if crop_w <= 0 or crop_h <= 0:
+            return ""
+        crop_filter = f"crop={crop_w}:{crop_h}:{crop_x1}:{crop_y1}"
+
+    if resize:
+        return f"{crop_filter},scale={resize}:{resize}"
+    return crop_filter
 
 
 def crop_frame(args):

--- a/mbari_aidata/generators/utils.py
+++ b/mbari_aidata/generators/utils.py
@@ -30,6 +30,8 @@ def build_roi_crop_filter(
     """
     width = x2 - x1
     height = y2 - y1
+    if width <= 0 or height <= 0:
+        return ""
     shorter_side = min(height, width)
     longer_side = max(height, width)
     padding = abs(longer_side - shorter_side) // 2
@@ -42,31 +44,35 @@ def build_roi_crop_filter(
         sq_y1 -= padding
         sq_y2 += padding
 
+    crop_x1 = max(0, sq_x1)
+    crop_y1 = max(0, sq_y1)
+    crop_x2 = min(media_width, sq_x2)
+    crop_y2 = min(media_height, sq_y2)
+    crop_w = crop_x2 - crop_x1
+    crop_h = crop_y2 - crop_y1
+    if crop_w <= 0 or crop_h <= 0:
+        return ""
+
     if fill:
-        ideal_size = sq_x2 - sq_x1
-        crop_x1 = max(0, sq_x1)
-        crop_y1 = max(0, sq_y1)
-        crop_x2 = min(media_width, sq_x2)
-        crop_y2 = min(media_height, sq_y2)
-        crop_w = crop_x2 - crop_x1
-        crop_h = crop_y2 - crop_y1
-        # Ensure coordinates don't go out of bounds
-        crop_x1, crop_x2, crop_y1, crop_y2 = max(0, crop_x1), min(media_width, crop_x2), max(0, crop_y1), min(media_height, crop_y2)
+        ideal_w = sq_x2 - sq_x1
+        ideal_h = sq_y2 - sq_y1
+        ideal_size = max(ideal_w, ideal_h, crop_w, crop_h)
+        if ideal_size <= 0:
+            return ""
+
         pad_x = crop_x1 - sq_x1
         pad_y = crop_y1 - sq_y1
+        if pad_x < 0 or pad_y < 0:
+            return ""
+
+        required_w = crop_w + pad_x
+        required_h = crop_h + pad_y
+        ideal_size = max(ideal_size, required_w, required_h)
         crop_filter = (
             f"crop={crop_w}:{crop_h}:{crop_x1}:{crop_y1},"
             f"pad={ideal_size}:{ideal_size}:{pad_x}:{pad_y}:{fill}"
         )
     else:
-        crop_x1 = max(0, sq_x1)
-        crop_y1 = max(0, sq_y1)
-        crop_x2 = min(media_width, sq_x2)
-        crop_y2 = min(media_height, sq_y2)
-        crop_w = crop_x2 - crop_x1
-        crop_h = crop_y2 - crop_y1 
-        # Ensure coordinates don't go out of bounds
-        crop_x1, crop_x2, crop_y1, crop_y2 = max(0, crop_x1), min(media_width, crop_x2), max(0, crop_y1), min(media_height, crop_y2)
         crop_filter = f"crop={crop_w}:{crop_h}:{crop_x1}:{crop_y1}"
 
     if resize:
@@ -85,10 +91,20 @@ def crop_frame(args):
     args.append(out)
     debug(' '.join(args))
     try:
-        subprocess.run(' '.join(args), check=False, shell=True)
+        subprocess.run(
+            ' '.join(args),
+            check=True,
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
         return 1
     except subprocess.CalledProcessError as e:
         err(str(e))
+        if e.stderr:
+            err(f"ffmpeg stderr: {e.stderr.strip()}")
+        if e.stdout:
+            debug(f"ffmpeg stdout: {e.stdout.strip()}")
         return 0
 
 def combine_localizations(boxes: List[Localization], iou_threshold: float = 0.5) -> List[Localization]:

--- a/mbari_aidata/generators/utils.py
+++ b/mbari_aidata/generators/utils.py
@@ -50,8 +50,8 @@ def build_roi_crop_filter(
         crop_y2 = min(media_height, sq_y2)
         crop_w = crop_x2 - crop_x1
         crop_h = crop_y2 - crop_y1
-        if crop_w <= 0 or crop_h <= 0:
-            return ""
+        # Ensure coordinates don't go out of bounds
+        crop_x1, crop_x2, crop_y1, crop_y2 = max(0, crop_x1), min(media_width, crop_x2), max(0, crop_y1), min(media_height, crop_y2)
         pad_x = crop_x1 - sq_x1
         pad_y = crop_y1 - sq_y1
         crop_filter = (
@@ -64,9 +64,9 @@ def build_roi_crop_filter(
         crop_x2 = min(media_width, sq_x2)
         crop_y2 = min(media_height, sq_y2)
         crop_w = crop_x2 - crop_x1
-        crop_h = crop_y2 - crop_y1
-        if crop_w <= 0 or crop_h <= 0:
-            return ""
+        crop_h = crop_y2 - crop_y1 
+        # Ensure coordinates don't go out of bounds
+        crop_x1, crop_x2, crop_y1, crop_y2 = max(0, crop_x1), min(media_width, crop_x2), max(0, crop_y1), min(media_height, crop_y2)
         crop_filter = f"crop={crop_w}:{crop_h}:{crop_x1}:{crop_y1}"
 
     if resize:

--- a/tests/test_roi_crop_filter.py
+++ b/tests/test_roi_crop_filter.py
@@ -1,0 +1,25 @@
+# mbari_aidata, Apache-2.0 license
+# Filename: tests/test_roi_crop_filter.py
+# Description: Tests the build_roi_crop_filter function
+from mbari_aidata.generators.utils import build_roi_crop_filter
+
+
+def test_build_roi_crop_filter_clips_without_fill():
+    # Tall box near the left edge: squaring expands horizontally past x=0.
+    result = build_roi_crop_filter(10, 50, 60, 150, 200, 200)
+    assert result == "crop=85:100:0:50"
+
+
+def test_build_roi_crop_filter_pads_with_white():
+    result = build_roi_crop_filter(10, 50, 60, 150, 200, 200, fill="white")
+    assert result == "crop=85:100:0:50,pad=100:100:15:0:white"
+
+
+def test_build_roi_crop_filter_pads_with_black_and_resize():
+    result = build_roi_crop_filter(170, 50, 210, 150, 200, 200, resize=224, fill="black")
+    assert result == "crop=60:100:140:50,pad=100:100:0:0:black,scale=224:224"
+
+
+def test_build_roi_crop_filter_pads_bottom_edge():
+    result = build_roi_crop_filter(50, 170, 150, 210, 200, 200, fill="white")
+    assert result == "crop=100:60:50:140,pad=100:100:0:0:white"

--- a/tests/test_roi_crop_filter.py
+++ b/tests/test_roi_crop_filter.py
@@ -23,3 +23,10 @@ def test_build_roi_crop_filter_pads_with_black_and_resize():
 def test_build_roi_crop_filter_pads_bottom_edge():
     result = build_roi_crop_filter(50, 170, 150, 210, 200, 200, fill="white")
     assert result == "crop=100:60:50:140,pad=100:100:0:0:white"
+
+
+def test_build_roi_crop_filter_fill_handles_odd_size_rounding():
+    # Height/width parity can differ by 1 after squaring + clipping near edges.
+    # The padded output must be >= cropped input in both dimensions.
+    result = build_roi_crop_filter(804, 606, 1361, 1164, 2048, 2048, fill="white")
+    assert result == "crop=557:558:804:606,pad=558:558:0:0:white"


### PR DESCRIPTION
When squaring ROI crops near image edges during download, --fill black or --fill white pads out-of-bounds regions instead of clipping them. Useful for microscopy media where objects sit near frame boundaries.

Fixes mbari-org/aidata#52