### PR TITLE
Feat/attribute dict

### DIFF
--- a/mbari_aidata/commands/load_common.py
+++ b/mbari_aidata/commands/load_common.py
@@ -2,12 +2,13 @@
 # Filename: commands/load_common.py
 # Description: Common functions for loading different media, e.g. images or video from a directory mapped to a web server
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import pandas as pd
 from tator.openapi.tator_openapi import TatorApi
 
 from mbari_aidata.logger import info, err
+from mbari_aidata.plugins.loaders.tator.attribute_utils import fetch_attribute_dict
 
 class MediaHelper:
     input_path: Path
@@ -25,9 +26,35 @@ def check_duplicate_media(api: TatorApi, project_id:int, media_type:int, df_medi
             media_names.append(name)
     return media_names
 
-def get_media_attributes(config_dict: Dict, media_type: str) -> dict:
-    attributes = config_dict["tator"][media_type.lower()]["attributes"]
-    return attributes
+def get_media_attributes(
+    config_dict: Dict,
+    media_type: str,
+    api: Optional[TatorApi] = None,
+    project_id: Optional[int] = None,
+) -> dict:
+    """Return the attribute mapping for *media_type*.
+
+    When *api* and *project_id* are supplied the mapping is fetched live from
+    the Tator project schema via :func:`fetch_attribute_dict`, which avoids
+    the need for a ``tator.<media_type>.attributes`` block in ``config.yml``.
+    The config file is used as a fallback (or when the API is not provided).
+
+    :param config_dict: Parsed YAML config dictionary.
+    :param media_type: Type key, e.g. ``"image"``, ``"video"``, ``"box"``.
+    :param api: Optional live :class:`TatorApi` instance.
+    :param project_id: Tator project ID (required when *api* is given).
+    :return: Attribute mapping ``{attr_name: {"type": dtype}, ...}``.
+    """
+    key = media_type.lower()
+
+    if api is not None and project_id is not None:
+        info(f"Fetching attribute dict for '{key}' from Tator project {project_id}")
+        attr_dict = fetch_attribute_dict(api, project_id)
+        if key in attr_dict:
+            return attr_dict[key]["attributes"]
+        info(f"Type '{key}' not found in project schema; falling back to config")
+
+    return config_dict["tator"][key]["attributes"]
 
 def check_mounts(config_dict: Dict, input:str, media_type: str) -> (MediaHelper, int):
     mounts = config_dict["mounts"]

--- a/mbari_aidata/generators/coco_voc.py
+++ b/mbari_aidata/generators/coco_voc.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 
 import tator  # type: ignore
 import pandas as pd
+from pascal_voc_writer import Writer  # type: ignore
 from PIL import Image
 from tqdm import tqdm
 from mbari_aidata.logger import debug, info, err, exception
@@ -193,7 +194,7 @@ def download(
         # See https://docs.mbari.org/deepsea-ai/data/ for more information
         label_path = output_path / "labels"
         label_path.mkdir(exist_ok=True)
-        media_path = output_path / "images"
+        media_path = output_path / "media"
         media_path.mkdir(exist_ok=True)
         voc_path = output_path / "voc"
         voc_path.mkdir(exist_ok=True)
@@ -211,6 +212,10 @@ def download(
 
         # Get all the media objects that match the criteria
         localizations_by_media_id = {}
+        fetched_media_by_id = {}  # cache media objects from initial queries for later attribute inspection
+
+        _VIDEO_EXTS = {".mp4", ".avi", ".mov", ".mkv", ".wmv"}
+
         def get_medias(concept_or_label=None):
             kwargs = {}
             if concept_or_label:
@@ -236,14 +241,17 @@ def download(
             medias = get_medias(f"concept::{concept}")
             for media in medias:
                 localizations_by_media_id[media.id] = []
+                fetched_media_by_id[media.id] = media
         for label in labels_list:
             medias = get_medias(f"Label::{label}")
             for media in medias:
                 localizations_by_media_id[media.id] = []
+                fetched_media_by_id[media.id] = media
         if not concepts_list and not labels_list:
             medias = get_medias()
             for media in medias:
                 localizations_by_media_id[media.id] = []
+                fetched_media_by_id[media.id] = media
 
         def query_localizations(prefix: str, query_str: str, max_records: int):
             # set inc to 5000 or max_records-1 or 1, whichever is larger
@@ -317,6 +325,31 @@ def download(
                 query_localizations("Label", label, num_label_records[label])
         if not concepts_list and not labels_list:
             query_localizations("", "", num_records)
+
+        # For Image-type media that carry a Label/label attribute on the media itself
+        # (image-level classification with no per-object box), inject a synthetic
+        # full-frame localization (x=0, y=0, w=1.0, h=1.0) so the whole image is
+        # treated as a single crop and the entry appears in localizations.csv.
+        for media_id, media in fetched_media_by_id.items():
+            if Path(media.name).suffix.lower() in _VIDEO_EXTS:
+                continue
+            attrs = media.attributes or {}
+            label = attrs.get("Label") or attrs.get("label")
+            if not label:
+                continue
+            full_frame_loc = tator.models.Localization(
+                x=0.0,
+                y=0.0,
+                width=1.0,
+                height=1.0,
+                media=media_id,
+                attributes={"Label": str(label)},
+                id=media_id,
+                frame=0,
+                elemental_id=media.elemental_id,
+            )
+            localizations_by_media_id[media_id].append(full_frame_loc)
+            debug(f"Injected full-frame localization for image {media.name} with label '{label}'")
 
         # Remove any media objects that do not have localizations
         for media_id in list(localizations_by_media_id.keys()):
@@ -392,10 +425,12 @@ def download(
 
         if not skip_image_download:
             # Download all the media files - this needs to be done before we can create the
-            # VOC/CIFAR files which reference the media file size
+            # VOC/CIFAR files which reference the media file size.
+            # Videos (.mp4) are also downloaded when crop_roi is set and no external_video_root
+            # is provided, since ROI cropping requires a local source file.
             for media in tqdm(all_media, desc="Downloading", unit="iteration"):
                 out_path = media_path / media.name
-                if '.mp4' in media.name:
+                if '.mp4' in media.name and not (crop_roi and external_video_root is None):
                     continue
                 if not out_path.exists() or out_path.stat().st_size == 0:
                     info(f"Downloading {media.name} to {out_path}")
@@ -460,8 +495,7 @@ def download(
 
                 # Resolve the crop source for this media.
                 # - If external_video_root is set, use it (stem match; .mov preferred, else .mp4 or .avi)
-                # - Else if Tator provides a streaming HTTP URL, use that
-                # - Else use the locally-downloaded media under media_path
+                # - Otherwise use the locally-downloaded file under media_path
                 if external_video_root is not None:
                     resolved = resolve_external_video_file(external_video_root, media.name)
                     if resolved is None:
@@ -471,14 +505,6 @@ def download(
                         )
                         continue
                     crop_source = resolved.as_posix()
-                    is_video_source = True
-                elif (
-                    hasattr(media.media_files, "streaming")
-                    and media.media_files.streaming
-                    and len(media.media_files.streaming) == 1
-                    and media.media_files.streaming[0].path.startswith("http")
-                ):
-                    crop_source = media.media_files.streaming[0].path
                     is_video_source = True
                 else:
                     crop_source = (media_path / media.name).as_posix()
@@ -525,7 +551,7 @@ def download(
         # Attribute columns are discovered dynamically so project-specific fields are included.
         all_localizations = [loc for locs in localizations_by_media_id.values() for loc in locs]
         localization_attribute_columns = get_localization_attribute_columns(all_localizations)
-        media_attribute_columns = get_media_attribute_columns(all_media)
+        media_attribute_columns = get_media_attribute_columns(all_media, exclude=localization_attribute_columns)
         header = ["media", "frame", "uuid"] + localization_attribute_columns + ["x", "y", "width", "height"] + media_attribute_columns
 
         with (output_path / "localizations.csv").open("w", newline="") as f:
@@ -551,7 +577,6 @@ def download(
             image_path = media_path / m.name
 
             # Get the image size — use PIL for images, Tator metadata for video
-            _VIDEO_EXTS = {".mp4", ".avi", ".mov", ".mkv", ".wmv"}
             is_video = Path(m.name).suffix.lower() in _VIDEO_EXTS
 
             if is_video:
@@ -566,58 +591,73 @@ def download(
                 image = Image.open(image_path)
                 image_width, image_height = image.size
 
-            with yolo_path.open("w") as f:
-                for loc in media_localizations:
-                    # Get the label index
-                    label_idx = labels.index(loc.attributes["Label"])
+            # Skip the YOLO .txt label file for images when cropping — the crop
+            # directory structure (crops/<label>/<id>.jpg) is the ground truth.
+            if not (crop_roi and not is_video):
+                with yolo_path.open("w") as f:
+                    for loc in media_localizations:
+                        # Get the label index
+                        label_idx = labels.index(loc.attributes["Label"])
 
-                    # Get the bounding box which is normalized to a 0-1 range and centered
-                    x = loc.x + loc.width / 2
-                    y = loc.y + loc.height / 2
-                    w = loc.width
-                    h = loc.height
-                    if save_score:
-                        f.write(f"{label_idx} {x} {y} {w} {h} {loc.attributes['score']}\n")
-                    else:
-                        f.write(f"{label_idx} {x} {y} {w} {h}\n")
+                        # Bounding box in Tator-native format: top-left (x, y), width, height, all normalized 0-1
+                        x = loc.x
+                        y = loc.y
+                        w = loc.width
+                        h = loc.height
+                        if save_score:
+                            f.write(f"{label_idx} {x} {y} {w} {h} {loc.attributes['score']}\n")
+                        else:
+                            f.write(f"{label_idx} {x} {y} {w} {h}\n")
 
             # optionally create VOC files
             if voc:
-                # Paths to the VOC file and the image
-                voc_xml_path = voc_path / f"{Path(m.name).stem}.xml"
-                image_path = (media_path / m.name).as_posix()
+                if crop_roi and not is_video:
+                    # For cropped image media: emit one XML per localization, with the
+                    # filename and path pointing to the crop file in crops/<label>/.
+                    # The bounding box spans the full crop (0, 0, crop_w, crop_h).
+                    for loc in media_localizations:
+                        crop_id = loc.elemental_id if loc.elemental_id else loc.id
+                        label = loc.attributes.get("Label", "Unknown")
+                        crop_file = crop_path / label / f"{crop_id}.jpg"
+                        voc_xml_path = voc_path / f"{crop_id}.xml"
 
-                writer = Writer(image_path, image_width, image_height)
+                        x1 = int(round(loc.x * image_width))
+                        y1 = int(round(loc.y * image_height))
+                        x2 = int(round((loc.x + loc.width) * image_width))
+                        y2 = int(round((loc.y + loc.height) * image_height))
+                        crop_w = max(1, x2 - x1)
+                        crop_h = max(1, y2 - y1)
 
-                # Add localizations
-                for loc in media_localizations:
-                    # Get the bounding box which is normalized to the image size and upper left corner
-                    x1 = loc.x
-                    y1 = loc.y
-                    x2 = loc.x + loc.width
-                    y2 = loc.y + loc.height
+                        crop_writer = Writer(crop_file.as_posix(), crop_w, crop_h)
+                        crop_writer.addObject(label, 0, 0, crop_w, crop_h, pose=str(loc.id))
+                        crop_writer.save(voc_xml_path.as_posix())
 
-                    x1 *= image_width
-                    y1 *= image_height
-                    x2 *= image_width
-                    y2 *= image_height
+                        with open(voc_xml_path, "r") as file:
+                            filedata = file.read()
+                        filedata = filedata.replace("pose", "id")
+                        with open(voc_xml_path, "w") as file:
+                            file.write(filedata)
+                else:
+                    # Original behavior: one XML per media with all localizations
+                    voc_xml_path = voc_path / f"{Path(m.name).stem}.xml"
+                    image_path = (media_path / m.name).as_posix()
 
-                    x1 = int(round(x1))
-                    y1 = int(round(y1))
-                    x2 = int(round(x2))
-                    y2 = int(round(y2))
+                    writer = Writer(image_path, image_width, image_height)
 
-                    writer.addObject(loc.attributes["Label"], x1, y1, x2, y2, pose=str(loc.id))
+                    for loc in media_localizations:
+                        x1 = int(round(loc.x * image_width))
+                        y1 = int(round(loc.y * image_height))
+                        x2 = int(round((loc.x + loc.width) * image_width))
+                        y2 = int(round((loc.y + loc.height) * image_height))
+                        writer.addObject(loc.attributes["Label"], x1, y1, x2, y2, pose=str(loc.id))
 
-                # Write the file
-                writer.save(voc_xml_path.as_posix())
+                    writer.save(voc_xml_path.as_posix())
 
-                # Replace the xml tag pose with uuid
-                with open(voc_xml_path, "r") as file:
-                    filedata = file.read()
-                filedata = filedata.replace("pose", "id")
-                with open(voc_xml_path, "w") as file:
-                    file.write(filedata)
+                    with open(voc_xml_path, "r") as file:
+                        filedata = file.read()
+                    filedata = filedata.replace("pose", "id")
+                    with open(voc_xml_path, "w") as file:
+                        file.write(filedata)
 
             if coco:
                 coco_localizations = []
@@ -651,6 +691,15 @@ def download(
                     )
 
                 json_content[yolo_path.as_posix()] = coco_localizations
+
+        # Remove downloaded image files that are redundant to crops
+        if crop_roi:
+            for m in all_media:
+                if Path(m.name).suffix.lower() not in _VIDEO_EXTS:
+                    local_file = media_path / m.name
+                    if local_file.exists():
+                        local_file.unlink()
+                        debug(f"Removed {local_file} (redundant to crops)")
 
         # optionally create a CIFAR formatted dataset
         if cifar:

--- a/mbari_aidata/generators/localization_csv.py
+++ b/mbari_aidata/generators/localization_csv.py
@@ -3,30 +3,38 @@
 # Description: Helper functions for generating a localizations CSV from Tator data
 from typing import Any, Iterable, List
 
+# Attribute keys that are always excluded from CSV output.
+# _tator_import_workflow is an internal Tator bookkeeping field with no
+# analytical value; Label is already a first-class localization column.
+_EXCLUDE_ATTRIBUTES = {"_tator_import_workflow"}
+
 
 def get_localization_attribute_columns(all_localizations: Iterable[Any]) -> List[str]:
     """
-    Collect the sorted union of all attribute keys across every localization.
-    Analogous to get_media_attribute_columns for media objects.
+    Collect the sorted union of all attribute keys across every localization,
+    excluding internal Tator bookkeeping fields.
     """
     columns: set = set()
     for loc in all_localizations:
         attributes = getattr(loc, "attributes", None)
         if attributes and hasattr(attributes, "keys"):
             columns.update(attributes.keys())
-    return sorted(columns)
+    return sorted(columns - _EXCLUDE_ATTRIBUTES)
 
 
-def get_media_attribute_columns(all_media: Iterable[Any]) -> List[str]:
+def get_media_attribute_columns(all_media: Iterable[Any], exclude: Iterable[str] = ()) -> List[str]:
     """
-    Collect the sorted union of all attribute keys across every media item.
+    Collect the sorted union of all attribute keys across every media item,
+    excluding internal Tator bookkeeping fields and any keys passed in *exclude*
+    (used to avoid duplicating columns already present in localization attributes).
     """
+    skip = _EXCLUDE_ATTRIBUTES | set(exclude)
     columns: set = set()
     for media in all_media:
         attributes = getattr(media, "attributes", None)
         if attributes and hasattr(attributes, "keys"):
             columns.update(attributes.keys())
-    return sorted(columns)
+    return sorted(columns - skip)
 
 
 def get_localization_csv_row(

--- a/mbari_aidata/plugins/loaders/tator/attribute_utils.py
+++ b/mbari_aidata/plugins/loaders/tator/attribute_utils.py
@@ -1,7 +1,8 @@
 # mbari_aidata, Apache-2.0 license
 # Filename: plugins/loaders/tator/attribute_utils.py
-# Description:  Database types
+# Description: Attribute type utilities and API-driven attribute dictionary builder
 from datetime import datetime
+from typing import Dict
 
 import pandas as pd
 import pytz
@@ -10,6 +11,83 @@ import pytz
 def attribute_to_dict(attribute):
     """Converts a Tator attribute to a dictionary."""
     return {attr.key: attr.value for attr in attribute}
+
+
+def fetch_attribute_dict(api, project_id: int) -> Dict[str, dict]:
+    """
+    Queries Tator for all media, localization, and state attribute definitions
+    in a project and returns a dict compatible with the ``tator:`` section of
+    ``config.yml``.
+
+    This lets callers build the attribute mapping at runtime from the live
+    project schema instead of hard-coding it in a YAML file.
+
+    Keys follow these conventions:
+
+    * **Media types** — keyed by ``dtype`` (``"image"`` or ``"video"``).
+      When multiple media types share the same dtype their attributes are
+      merged; the first type encountered also registers a name-based key
+      (``type_name.lower().replace(" ", "_")``).
+    * **Localization types** — keyed by ``dtype`` (``"box"``, ``"line"``,
+      ``"dot"``).  A name-based key is also registered so that distinct
+      types with the same dtype (e.g. ``"Box"`` and ``"TDWA Box"``) remain
+      individually addressable.
+    * **State types** — keyed by name (lowercased, spaces replaced with
+      underscores), e.g. ``"track_state"``.
+
+    Each entry has the shape::
+
+        {
+            "<key>": {
+                "attributes": {
+                    "<attr_name>": {"type": "<dtype>"},
+                    ...
+                }
+            }
+        }
+
+    :param api: :class:`tator.openapi.tator_openapi.TatorApi` instance.
+    :param project_id: Tator project ID.
+    :return: Attribute dictionary keyed by type name/dtype.
+    """
+    result: Dict[str, dict] = {}
+
+    # --- Media types (image / video) ---
+    for mt in api.get_media_type_list(project=project_id):
+        attrs = {a.name: {"type": a.dtype} for a in (mt.attribute_types or [])}
+        dtype_key = mt.dtype  # "image" or "video"
+        name_key = mt.name.lower().replace(" ", "_")
+
+        # Merge into the dtype-keyed bucket (backward-compat with config.yml)
+        if dtype_key not in result:
+            result[dtype_key] = {"attributes": attrs}
+        else:
+            result[dtype_key]["attributes"].update(attrs)
+
+        # Also register under the type name so named lookups work
+        if name_key not in result:
+            result[name_key] = {"attributes": attrs}
+
+    # --- Localization types (box / line / dot) ---
+    for lt in api.get_localization_type_list(project=project_id):
+        attrs = {a.name: {"type": a.dtype} for a in (lt.attribute_types or [])}
+        dtype_key = lt.dtype  # "box", "line", or "dot"
+        name_key = lt.name.lower().replace(" ", "_")
+
+        # Name-based key for uniquely addressable types (e.g. "tdwa_box")
+        result[name_key] = {"attributes": attrs}
+
+        # dtype key: first type wins so "box" maps to the primary Box type
+        if dtype_key not in result:
+            result[dtype_key] = {"attributes": attrs}
+
+    # --- State types ---
+    for st in api.get_state_type_list(project=project_id):
+        attrs = {a.name: {"type": a.dtype} for a in (st.attribute_types or [])}
+        key = st.name.lower().replace(" ", "_")
+        result[key] = {"attributes": attrs}
+
+    return result
 
 
 def format_attributes(attributes: dict, attribute_mapping: dict) -> dict:

--- a/tests/test_attribute_dict.py
+++ b/tests/test_attribute_dict.py
@@ -1,0 +1,217 @@
+# mbari_aidata, Apache-2.0 license
+# Filename: tests/test_attribute_dict.py
+# Description: Unit tests for fetch_attribute_dict – no live Tator instance required
+from unittest.mock import MagicMock
+
+import pytest
+
+from mbari_aidata.plugins.loaders.tator.attribute_utils import fetch_attribute_dict
+from mbari_aidata.commands.load_common import get_media_attributes
+
+
+# ---------------------------------------------------------------------------
+# Helpers – build lightweight mock attribute-type objects
+# ---------------------------------------------------------------------------
+
+def _make_attr(name: str, dtype: str) -> MagicMock:
+    a = MagicMock()
+    a.name = name
+    a.dtype = dtype
+    return a
+
+
+def _make_media_type(name: str, dtype: str, attrs) -> MagicMock:
+    mt = MagicMock()
+    mt.name = name
+    mt.dtype = dtype
+    mt.attribute_types = attrs
+    return mt
+
+
+def _make_loc_type(name: str, dtype: str, attrs) -> MagicMock:
+    lt = MagicMock()
+    lt.name = name
+    lt.dtype = dtype
+    lt.attribute_types = attrs
+    return lt
+
+
+def _make_state_type(name: str, attrs) -> MagicMock:
+    st = MagicMock()
+    st.name = name
+    st.attribute_types = attrs
+    return st
+
+
+def _build_api():
+    """Return a mock TatorApi with a realistic project schema."""
+    api = MagicMock()
+
+    api.get_media_type_list.return_value = [
+        _make_media_type("Image", "image", [
+            _make_attr("video_reference_uuid", "string"),
+            _make_attr("iso_start_datetime", "datetime"),
+        ]),
+        _make_media_type("Video", "video", [
+            _make_attr("video_reference_uuid", "string"),
+            _make_attr("depth", "float"),
+        ]),
+    ]
+
+    api.get_localization_type_list.return_value = [
+        _make_loc_type("Box", "box", [
+            _make_attr("Label", "string"),
+            _make_attr("score", "float"),
+            _make_attr("cluster", "string"),
+            _make_attr("verified", "bool"),
+        ]),
+        _make_loc_type("TDWA Box", "box", [
+            _make_attr("Label", "string"),
+            _make_attr("avg_score", "float"),
+        ]),
+    ]
+
+    api.get_state_type_list.return_value = [
+        _make_state_type("Track State", [
+            _make_attr("label", "string"),
+            _make_attr("avg_score", "float"),
+            _make_attr("max_score", "float"),
+        ]),
+    ]
+
+    return api
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestFetchAttributeDict:
+    def setup_method(self):
+        self.api = _build_api()
+        self.result = fetch_attribute_dict(self.api, project_id=42)
+
+    def test_api_called_with_correct_project(self):
+        self.api.get_media_type_list.assert_called_once_with(project=42)
+        self.api.get_localization_type_list.assert_called_once_with(project=42)
+        self.api.get_state_type_list.assert_called_once_with(project=42)
+
+    # Media types
+    def test_image_dtype_key_present(self):
+        assert "image" in self.result
+
+    def test_image_attributes_correct(self):
+        attrs = self.result["image"]["attributes"]
+        assert attrs["video_reference_uuid"] == {"type": "string"}
+        assert attrs["iso_start_datetime"] == {"type": "datetime"}
+
+    def test_video_dtype_key_present(self):
+        assert "video" in self.result
+
+    def test_video_attributes_correct(self):
+        attrs = self.result["video"]["attributes"]
+        assert attrs["video_reference_uuid"] == {"type": "string"}
+        assert attrs["depth"] == {"type": "float"}
+
+    def test_image_name_key_also_registered(self):
+        # "Image" → "image" name key (same as dtype here, still present)
+        assert "image" in self.result
+
+    # Localization types
+    def test_primary_box_dtype_key_present(self):
+        assert "box" in self.result
+
+    def test_primary_box_attributes_correct(self):
+        # "box" dtype key should map to the *first* localization type ("Box")
+        attrs = self.result["box"]["attributes"]
+        assert "Label" in attrs
+        assert "score" in attrs
+        assert "verified" in attrs
+
+    def test_tdwa_box_name_key_present(self):
+        assert "tdwa_box" in self.result
+
+    def test_tdwa_box_attributes_correct(self):
+        attrs = self.result["tdwa_box"]["attributes"]
+        assert attrs["Label"] == {"type": "string"}
+        assert attrs["avg_score"] == {"type": "float"}
+
+    # State types
+    def test_track_state_key_present(self):
+        assert "track_state" in self.result
+
+    def test_track_state_attributes_correct(self):
+        attrs = self.result["track_state"]["attributes"]
+        assert attrs["label"] == {"type": "string"}
+        assert attrs["avg_score"] == {"type": "float"}
+        assert attrs["max_score"] == {"type": "float"}
+
+    def test_no_extra_keys_from_state(self):
+        # State types should NOT produce a dtype key (they have no dtype)
+        assert "media" not in self.result
+        assert "localization" not in self.result
+
+    def test_returns_dict(self):
+        assert isinstance(self.result, dict)
+
+
+class TestFetchAttributeDictEmptyProject:
+    """Edge case: project with no types defined."""
+
+    def test_empty_project_returns_empty_dict(self):
+        api = MagicMock()
+        api.get_media_type_list.return_value = []
+        api.get_localization_type_list.return_value = []
+        api.get_state_type_list.return_value = []
+        result = fetch_attribute_dict(api, project_id=1)
+        assert result == {}
+
+
+class TestFetchAttributeDictNoneAttributeTypes:
+    """Edge case: attribute_types is None (some Tator versions return None)."""
+
+    def test_none_attribute_types_handled(self):
+        api = MagicMock()
+        mt = _make_media_type("Image", "image", None)
+        api.get_media_type_list.return_value = [mt]
+        api.get_localization_type_list.return_value = []
+        api.get_state_type_list.return_value = []
+        result = fetch_attribute_dict(api, project_id=1)
+        assert result["image"]["attributes"] == {}
+
+
+class TestGetMediaAttributesWithApi:
+    """Tests for the updated get_media_attributes() helper."""
+
+    def test_returns_from_api_when_provided(self):
+        api = _build_api()
+        config_dict = {}  # no tator section needed
+        attrs = get_media_attributes(config_dict, "image", api=api, project_id=42)
+        assert "video_reference_uuid" in attrs
+
+    def test_falls_back_to_config_when_no_api(self):
+        config_dict = {
+            "tator": {
+                "image": {
+                    "attributes": {"my_attr": {"type": "string"}}
+                }
+            }
+        }
+        attrs = get_media_attributes(config_dict, "image")
+        assert attrs == {"my_attr": {"type": "string"}}
+
+    def test_falls_back_to_config_when_type_missing_from_api(self):
+        """If the API schema doesn't have the requested type, use config."""
+        api = MagicMock()
+        api.get_media_type_list.return_value = []
+        api.get_localization_type_list.return_value = []
+        api.get_state_type_list.return_value = []
+        config_dict = {
+            "tator": {
+                "image": {
+                    "attributes": {"fallback_attr": {"type": "int"}}
+                }
+            }
+        }
+        attrs = get_media_attributes(config_dict, "image", api=api, project_id=1)
+        assert attrs == {"fallback_attr": {"type": "int"}}


### PR DESCRIPTION
Closes #69

## Summary

Reads project media and localization attribute definitions directly from
the Tator API instead of requiring a hand-authored `tator:` section in
`config.yml`. Alongside that, a set of related improvements to the
`download dataset --crop-roi` pipeline for image media.

## Changes

### `fetch_attribute_dict` — core feature (closes #69)

`plugins/loaders/tator/attribute_utils.py` gains `fetch_attribute_dict(api, project_id)`.
It calls `get_media_type_list`, `get_localization_type_list`, and
`get_state_type_list` and returns a dict compatible with the `tator:`
section of `config.yml`:

```python
{
    "image":       {"attributes": {"attr_name": {"type": "datetime"}, ...}},
    "video":       {"attributes": {...}},
    "box":         {"attributes": {...}},
    "tdwa_box":    {"attributes": {...}},   # name-keyed, distinct from "box"
    "track_state": {"attributes": {...}},
}
```

`commands/load_common.get_media_attributes()` now accepts optional
`api` + `project_id`; when provided it fetches live and falls back to
config if the type is not found, so all existing callers are unchanged.

19 unit tests added (no live Tator instance required).

### `download dataset --crop-roi` image pipeline

| Area | Change |
|---|---|
| **Video source** | Download the video locally before cropping instead of streaming from Tator. `--external-video-root` still overrides. |
| **Output layout** | `images/` renamed to `media/` |
| **Image-level labels** | Image media with a `Label`/`label` attribute on the media itself gets a synthetic full-frame localization `(x=0, y=0, w=1.0, h=1.0)`, so the whole image is included as a crop and a row in `localizations.csv` |
| **Crop filename** | Uses `media.elemental_id` (UUID) instead of integer media ID |
| **YOLO labels** | Written in Tator-native top-left format `(x, y, w, h)`; `.txt` files skipped for image media when `--crop-roi` is set (crops are the ground truth) |
| **VOC XML** | For image media with `--crop-roi`: one XML per localization named `<elemental_id>.xml`, `<path>` points to `crops/<label>/<elemental_id>.jpg`, bounding box is full-frame of the crop |
| **Cleanup** | Downloaded image files under `media/` are deleted after cropping |
| **`localizations.csv`** | `_tator_import_workflow` column dropped; `Label` deduplicated (was appearing from both localization and media attributes) |

## Labels

`type/feature` · `scope/generators` · `scope/plugins` · `impact/medium` · `status/needs-review`