### PR TITLE
fix(generators): apply section filter when paging localizations in download

### DIFF
--- a/mbari_aidata/generators/coco_voc.py
+++ b/mbari_aidata/generators/coco_voc.py
@@ -330,6 +330,8 @@ def download(
                     kwargs["attribute_gt"] = attribute_gt
                 if attribute_lt:
                     kwargs["attribute_lt"] = attribute_lt
+                if section_id:
+                    kwargs["section"] = section_id
 
                 info(f"Query records {start} to {start + inc} using {kwargs} {prefix} {query_str}")
 


### PR DESCRIPTION
## Problem

`aidata download dataset --section <name> ...` finds the correct localization/media counts during the initial query phase, but then downloads 0 images/crops when a `--section` filter is used.

Example from a real run against section `300m`:
```
Found 38519 localizations with {..., 'section': 482}
Found 17720 media with matching direct attributes
...
Found 0 records for version [...], section 300m, and including ['Unknown']
Cropping 0 ROIs...
```

## Root cause

In `mbari_aidata/generators/coco_voc.py`, `download()` selects matching media via `get_localization_count()` / `get_medias()`, both of which correctly pass `section=section_id` to the Tator API.

However, the actual paginated fetch of `Localization` objects (`query_localizations()` → `api.get_localization_list(...)`) never included the `section` filter. This caused it to page through localizations across the **entire project** (bounded by an inflated `max_records`), instead of the target section. Localizations were filtered afterward by checking `l.media` against the section-restricted media dict, so the scan could exhaust its record budget before ever encountering a localization whose media fell inside the target section — resulting in 0 matches and no downloaded images/crops.

## Fix

Add the missing `section` filter to `query_localizations()`'s `kwargs`, matching the filtering already applied in `get_localization_count()` and `get_medias()`.

## Testing

- `pytest tests/test_coco_voc_localizations_csv.py` — 13 passed.
- Full local suite: 54 passed, 4 skipped, 7 pre-existing failures unrelated to this change (require a live Tator server at `localhost:8080`).

Made with [Cursor](https://cursor.com)